### PR TITLE
fix: 음성채팅 참가 예외처리 버그 수정 #199

### DIFF
--- a/src/components/call/VideoContainer.tsx
+++ b/src/components/call/VideoContainer.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import io from 'socket.io-client'
 import useUserStore from '../../store/userStore'
 import { Container, UserLabel, MyAudio, ProfileImage } from './VideoStyles'
@@ -50,6 +50,7 @@ const VideoContainer = ({
   const localStreamRef = useRef<MediaStream>()
   const [users, setUsers] = useState<WebRTCUser[]>([])
   const navigate = useNavigate()
+  const params = useParams()
 
   const token = localStorage.getItem('access_token')
   const nickname = useUserStore((state) => state.nickname)
@@ -159,7 +160,7 @@ const VideoContainer = ({
 
     socketRef.current.on('error_message', (data: SocketError) => {
       toast.info(data.error.message)
-      navigate(-1)
+      navigate(`/objets/${params.oid}`)
     })
 
     socketRef.current.on(


### PR DESCRIPTION
## 📝 개요

- 음성채팅 참가시 발생할 수 있는 예외가 제대로 처리되지 않는 버그를 수정했습니다.

## 🐛 변경 사항

- 음성채팅 참가 예외처리 버그 수정

  - 🐛 navigate(-1) 대신 음성채팅방에 해당하는 오브제 상세조회 페이지 명시적 지정

## 🔗 관련 이슈

- 이 PR과 관련된 이슈 번호를 연결합니다. (없으면 생략))
  - 예: closes #199