### PR TITLE
[기능] 모바일 라운지 상세 뷰 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-lottie": "^1.2.10",
         "@types/socket.io-client": "1.4.34",
         "@types/three": "^0.167.1",
+        "@uidotdev/usehooks": "^2.4.1",
         "antd": "^5.20.1",
         "axios": "^1.7.7",
         "event-source-polyfill": "^1.0.31",
@@ -3607,6 +3608,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uidotdev/usehooks": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@uidotdev/usehooks/-/usehooks-2.4.1.tgz",
+      "integrity": "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/react-lottie": "^1.2.10",
     "@types/socket.io-client": "1.4.34",
     "@types/three": "^0.167.1",
+    "@uidotdev/usehooks": "^2.4.1",
     "antd": "^5.20.1",
     "axios": "^1.7.7",
     "event-source-polyfill": "^1.0.31",

--- a/src/pages/lounge/Lounge.tsx
+++ b/src/pages/lounge/Lounge.tsx
@@ -17,6 +17,8 @@ import LoadingLottie from '@components/lotties/LoadingLottie'
 import { LoungeDrop } from '@components/dropdown/Dropdown'
 import useUserStore from '@store/userStore'
 import { toast } from 'react-toastify'
+import { useMediaQuery } from '@uidotdev/usehooks'
+import MobileLoungeObjets from './MobileLoungeObjets'
 import { DeleteLoungeModal, WithDrawLoungeModal } from '@components/modal/Modal'
 import axios from 'axios'
 import { useQuery, useMutation, useQueryClient } from 'react-query'
@@ -28,6 +30,19 @@ const fetchLounge = async (loungeId: string) => {
     },
     withCredentials: true,
   })
+  return response.data.data
+}
+
+const fetchLoungeObjets = async (loungeId: string) => {
+  const response = await axios.get(
+    `${APIs.objet}?lounge_id=${loungeId}&is_owner=false`,
+    {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('access_token')}`,
+      },
+      withCredentials: true,
+    }
+  )
   return response.data.data
 }
 
@@ -57,6 +72,7 @@ const withdrawLounge = async (loungeId: string) => {
 
 export default function Lounge() {
   const { lid: loungeId } = useParams<{ lid: string }>()
+  const isMobile = useMediaQuery('only screen and (max-width : 425px)')
   const navigate = useNavigate()
   const userId = useUserStore((state) => state.userId)
   const queryClient = useQueryClient()
@@ -74,6 +90,16 @@ export default function Lounge() {
       onError: () => {
         toast.error('해당 라운지를 찾을 수 없습니다 😅')
         navigate(`${URL.lounge}`)
+      },
+    }
+  )
+
+  const { data: objets } = useQuery(
+    ['loungeObjet', loungeId],
+    () => fetchLoungeObjets(loungeId!),
+    {
+      onError: () => {
+        toast.error('해당 라운지의 오브제가 없습니다 😅')
       },
     }
   )
@@ -160,14 +186,16 @@ export default function Lounge() {
           <GlobalSubTitle>
             친구를 초대하고 오브제로 추억을 공유해보세요!
           </GlobalSubTitle>
-          <Objets>
+          <Objets style={{ alignItems: `${isMobile && 'flex-start'}` }}>
             {isLoading ? (
               <LoadingLottie />
-            ) : (
-              <LoungeObjets
-                objets={loungeData?.objets || []}
+            ) : isMobile ? (
+              <MobileLoungeObjets
+                objets={objets || []}
                 loungeId={Number(loungeId)}
               />
+            ) : (
+              <LoungeObjets objets={objets || []} loungeId={Number(loungeId)} />
             )}
           </Objets>
         </GloablContainer16>

--- a/src/pages/lounge/LoungeStyles.tsx
+++ b/src/pages/lounge/LoungeStyles.tsx
@@ -142,7 +142,6 @@ export const LoungeTitle = styled.div`
 `
 
 export const Objets = styled.div`
-  border: 0.1px solid gray;
   display: flex;
   margin-top: 30px;
   width: 100%;

--- a/src/pages/lounge/MiniObjetCardStyles.tsx
+++ b/src/pages/lounge/MiniObjetCardStyles.tsx
@@ -1,0 +1,72 @@
+import styled from 'styled-components'
+
+export const CardList = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 30px;
+`
+
+export const CardContainer = styled.div`
+  margin-bottom: 40px;
+  width: 100%;
+  height: fit-content;
+  color: black;
+`
+
+export const Line = styled.div`
+  margin-top: 30px;
+  width: 100%;
+  height: 0.5px;
+  background-color: #272727;
+`
+
+export const User = styled.div`
+  width: 100%;
+  height: fit-content;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: flex-start;
+
+  > img {
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+  }
+
+  > div {
+    font-size: 17px;
+    color: #dedede;
+  }
+`
+
+export const TopContainer = styled.div`
+  width: 100%;
+  height: fit-content;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: white;
+
+  > div {
+    width: fit-content;
+    font-size: 11px;
+    color: #dedede;
+  }
+`
+
+export const ObjetContainer = styled.div`
+  width: 100%;
+  height: fit-content;
+
+  > img {
+    margin-top: 20px;
+    width: 100%;
+  }
+
+  > div {
+    margin-top: 20px;
+    color: #dedede;
+    font-size: 16px;
+  }
+`

--- a/src/pages/lounge/MobileLoungeObjets.tsx
+++ b/src/pages/lounge/MobileLoungeObjets.tsx
@@ -1,0 +1,49 @@
+import type { Objet } from '@/types/ModelType'
+import {
+  Line,
+  CardContainer,
+  User,
+  ObjetContainer,
+  CardList,
+  TopContainer,
+} from './MiniObjetCardStyles'
+import { useNavigate } from 'react-router-dom'
+import { URL } from '@/static'
+import { extractYearMonthDate2 } from '@/utils/formatDatetime'
+
+export default function MobileLoungeObjets({
+  objets,
+}: {
+  objets: Objet[]
+  loungeId: number
+}) {
+  const navigate = useNavigate()
+
+  return (
+    <CardList>
+      {objets?.map((objet, index) => {
+        return (
+          <CardContainer
+            key={objet.objet_id}
+            onClick={() => navigate(`${URL.objet}/${objet.objet_id}`)}
+          >
+            <TopContainer>
+              <User>
+                <img src={objet.owner?.profile_image} />
+                <div>{objet.owner?.nickname}</div>
+              </User>
+              <div>
+                {objet.created_at && extractYearMonthDate2(objet.created_at)}
+              </div>
+            </TopContainer>
+            <ObjetContainer>
+              <img src={objet.objet_image} />
+              <div>{objet.name}</div>
+            </ObjetContainer>
+            {index !== objets.length - 1 && <Line />}
+          </CardContainer>
+        )
+      })}
+    </CardList>
+  )
+}

--- a/src/pages/myRoom/MyRoomObjets.tsx
+++ b/src/pages/myRoom/MyRoomObjets.tsx
@@ -16,6 +16,8 @@ import { APIs } from '@/static'
 import LoadingLottie from '@components/lotties/LoadingLottie'
 import { useQuery } from 'react-query'
 import axios from 'axios'
+import { useMediaQuery } from '@uidotdev/usehooks'
+import MobileLoungeObjets from '../lounge/MobileLoungeObjets'
 
 interface Lounge {
   lounge_id: number
@@ -24,6 +26,7 @@ interface Lounge {
 }
 
 export default function MyRoomObjet() {
+  const isMobile = useMediaQuery('only screen and (max-width : 425px)')
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [selectedLounge, setSelectedLounge] = useState<Lounge>({
     lounge_id: 0,
@@ -120,11 +123,18 @@ export default function MyRoomObjet() {
           </TopContainer>
           <GlobalSubTitle>나에게 전달된 오브제를 확인해보세요!</GlobalSubTitle>
           {!isObjetsLoading && objets ? (
-            <Objets>
-              <LoungeObjets
-                objets={objets}
-                loungeId={selectedLounge.lounge_id}
-              />
+            <Objets style={{ alignItems: `${isMobile && 'flex-start'}` }}>
+              {isMobile ? (
+                <MobileLoungeObjets
+                  objets={objets || []}
+                  loungeId={Number(selectedLounge.lounge_id)}
+                />
+              ) : (
+                <LoungeObjets
+                  objets={objets || []}
+                  loungeId={Number(selectedLounge.lounge_id)}
+                />
+              )}
             </Objets>
           ) : (
             <LoadingLottie />

--- a/src/types/ModelType.ts
+++ b/src/types/ModelType.ts
@@ -16,5 +16,10 @@ export interface Objet {
   objet_type: 'O0001' | 'O0002' | 'O0003'
   name: string
   description: string
-  objet_image: File
+  created_at?: string
+  objet_image: string
+  owner?: {
+    nickname: string
+    profile_image: string
+  }
 }

--- a/src/utils/formatDatetime.tsx
+++ b/src/utils/formatDatetime.tsx
@@ -29,3 +29,13 @@ export const extractTime = (datetime: string) => {
 
   return timeString
 }
+
+export const extractYearMonthDate2 = (datetime: string) => {
+  const date = new Date(datetime)
+
+  const year = (date.getFullYear() % 100).toString().padStart(2, '0')
+  const month = (date.getMonth() + 1).toString().padStart(2, '0')
+  const day = date.getDate().toString().padStart(2, '0')
+
+  return `${year}년 ${month}월 ${day}일`
+}


### PR DESCRIPTION
## 📝 개요

- 이 PR은 모바일에서 라운지 상세 페이지 뷰 수정을 위한 pr입니다.

## ✨ 변경 사항

  - ✨ 라운지 상세 모바일 뷰 구현
  
## 📸 스크린샷 (옵션)

|라운지 상세|
|:---:|
|![image](https://github.com/user-attachments/assets/03661be7-9c69-4d64-b059-e9826de18aa0)|

## ℹ️ 참고 사항

- 내 오브제 조회 - 라운지 전체 에서는 아직 api가 수정되지 않아 유저의 이미지 및 생성 날짜가 미표시됩니다.
