### PR TITLE
[수정] use-query 재시도 횟수 제한

### DIFF
--- a/src/components/lounge/LoungeContainer.tsx
+++ b/src/components/lounge/LoungeContainer.tsx
@@ -35,6 +35,7 @@ export default function LoungeContainer() {
     isLoading,
     isError,
   } = useQuery('loungeList', getLoungeList, {
+    retry: 1,
     onError: (error) => {
       console.error('Failed to fetch lounge list', error)
     },

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -43,6 +43,9 @@ const useNotifications = () => {
     isLoading,
   } = useQuery('notifications', fetchNotifications, {
     retry: 1,
+    onError: (error) => {
+      console.error('Failed to fetch notifications', error)
+    },
   })
 
   return { notificationList, error, isLoading }

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -39,7 +39,13 @@ export default function Home() {
 
   const { data: objets = [], isLoading } = useQuery(
     ['objets', userId],
-    fetchObjetPreviews
+    fetchObjetPreviews,
+    {
+      retry: 1,
+      onError: (error) => {
+        console.error('Failed to fetch objets', error)
+      },
+    }
   )
 
   return (

--- a/src/pages/lounge/Lounge.tsx
+++ b/src/pages/lounge/Lounge.tsx
@@ -87,6 +87,7 @@ export default function Lounge() {
     ['lounge', loungeId],
     () => fetchLounge(loungeId!),
     {
+      retry: 1,
       onError: () => {
         toast.error('해당 라운지를 찾을 수 없습니다 😅')
         navigate(`${URL.lounge}`)
@@ -98,6 +99,7 @@ export default function Lounge() {
     ['loungeObjet', loungeId],
     () => fetchLoungeObjets(loungeId!),
     {
+      retry: 1,
       onError: () => {
         toast.error('해당 라운지의 오브제가 없습니다 😅')
       },

--- a/src/pages/lounge/NewLounge.tsx
+++ b/src/pages/lounge/NewLounge.tsx
@@ -67,6 +67,7 @@ export default function NewLounge() {
   const queryClient = useQueryClient()
 
   useQuery('lounges', fetchLoungeList, {
+    retry: 1,
     onSuccess: (data) => {
       if (data.length >= 4) {
         toast.error('라운지 갯수 제한(최대 4개) 🥹')

--- a/src/pages/myRoom/CreateMyRoom.tsx
+++ b/src/pages/myRoom/CreateMyRoom.tsx
@@ -52,6 +52,7 @@ export default function CreateMyRoom() {
 
   // 마이룸 생성 여부를 체크하는 쿼리
   useQuery(['checkMyRoom', userId], () => checkIfGenerated(userId), {
+    retry: 1,
     onSuccess: (response) => {
       if (response.status === 200) {
         toast.info(

--- a/src/pages/myRoom/MyRoom.tsx
+++ b/src/pages/myRoom/MyRoom.tsx
@@ -70,6 +70,7 @@ export default function MyRoom() {
     ['myRoom', userId],
     () => fetchMyRoomInfo(userId),
     {
+      retry: 1,
       onSuccess: (data) => {
         setMyRoomNameForChange(
           data?.my_room_name ? data.my_room_name : userNickname + '의 마이룸'

--- a/src/pages/myRoom/MyRoomObjets.tsx
+++ b/src/pages/myRoom/MyRoomObjets.tsx
@@ -73,12 +73,22 @@ export default function MyRoomObjet() {
     isLoading: isObjetsLoading,
     refetch: refetchObjets,
   } = useQuery(['objets', loungeId], () => fetchLoungeObjets(loungeId), {
+    retry: 1,
     enabled: true,
+    onError: (error) => {
+      console.error('Failed to fetch objets', error)
+    },
   })
 
   const { data: lounges, isLoading: isLoungesLoading } = useQuery<Lounge[]>(
     'lounges',
-    () => fetchLounges()
+    fetchLounges,
+    {
+      retry: 1,
+      onError: (error) => {
+        console.error('Failed to fetch lounges', error)
+      },
+    }
   )
 
   const handleSelectLounge = (loungeId: number) => {

--- a/src/pages/notification/Notification.tsx
+++ b/src/pages/notification/Notification.tsx
@@ -18,7 +18,7 @@ import { useNavigate } from 'react-router-dom'
 import { APIs } from '@/static'
 import { useQuery } from 'react-query'
 import axios from 'axios'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 
 const fetchNotifications = async (cursor: number | null = null) => {
   const response = await axios.get(
@@ -50,6 +50,7 @@ export default function Notification() {
     ['notifications', cursor],
     () => fetchNotifications(cursor),
     {
+      retry: 1,
       enabled: false,
       onSuccess: (data) => {
         setNotifications((prev) => [...prev, ...data.data])
@@ -59,13 +60,13 @@ export default function Notification() {
     }
   )
 
-  const loadMoreNotifications = async () => {
+  const loadMoreNotifications = useCallback(async () => {
     if (hasNext && !isFetching) {
       setIsFetching(true)
       await refetch()
       setIsFetching(false)
     }
-  }
+  }, [hasNext, isFetching, refetch])
 
   useEffect(() => {
     const handleObserver = (entries: IntersectionObserverEntry[]) => {

--- a/src/pages/objet/Objet.tsx
+++ b/src/pages/objet/Objet.tsx
@@ -54,6 +54,7 @@ export default function Objet() {
       return response.data.data
     },
     {
+      retry: 1,
       onError: () => {
         toast.error('해당 오브제를 찾을 수 없습니다 😅')
         navigate(`${URL.lounge}`)
@@ -75,6 +76,12 @@ export default function Objet() {
       )
 
       return response.data.data.calling_user_num
+    },
+    {
+      retry: 1,
+      onError: () => {
+        console.error('Failed to fetch calling people')
+      },
     }
   )
 

--- a/src/pages/objet/ObjetDetail.tsx
+++ b/src/pages/objet/ObjetDetail.tsx
@@ -67,6 +67,7 @@ export default function ObjetDetail() {
       }
     },
     {
+      retry: 1,
       onError: (error) => {
         console.error('오브제 정보 가져오기 실패: ', error)
         toast.error('오브제 정보를 가져오지 못했습니다.')

--- a/src/pages/objet/ObjetForm.tsx
+++ b/src/pages/objet/ObjetForm.tsx
@@ -64,6 +64,7 @@ export default function ObjetForm() {
       }
     },
     {
+      retry: 1,
       enabled: step === 'update',
       onSuccess: (data) => {
         setSelectedType(data?.objet_type || '')

--- a/src/pages/user/FirstProfile.tsx
+++ b/src/pages/user/FirstProfile.tsx
@@ -39,6 +39,7 @@ export default function FirstProfile() {
     'userProfile',
     fetchUserProfile,
     {
+      retry: 1,
       onSuccess: (data) => {
         if (data.user_status !== 'ACTIVE_FIRST_LOGIN') {
           toast.info('이미 프로필을 설정했습니다 😊')

--- a/src/pages/user/UserDetail.tsx
+++ b/src/pages/user/UserDetail.tsx
@@ -55,6 +55,7 @@ export default function UserDetail() {
     ['userInfo', userId],
     fetchUserInfo,
     {
+      retry: 1,
       onSuccess: (data) => {
         setUserNickname(data.nickname)
         setUserProfileUrl(data.profile_url)
@@ -70,6 +71,7 @@ export default function UserDetail() {
     ['myRoomInfo', userId],
     fetchMyRoomInfo,
     {
+      retry: 1,
       onSuccess: (data) => {
         setMyRoomName(
           data.my_room_name ? data.my_room_name : profile.nickname + '의 마이룸'

--- a/src/pages/user/UserList.tsx
+++ b/src/pages/user/UserList.tsx
@@ -63,6 +63,7 @@ export default function UserList() {
     ['searchUser', debouncedSearchUser],
     () => searchUsers(debouncedSearchUser),
     {
+      retry: 1,
       enabled: !!debouncedSearchUser,
       onError: (error) => {
         console.error('유저 검색 실패', error)


### PR DESCRIPTION
## 📝 개요

- use-query 재시도 횟수 제한

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

  - ✨ use-query 재시도 횟수를 1번으로 제한

## ℹ️ 참고 사항

- 라운지 초대 수락할 경우, 삭제된 라운지에 대해 라운지 상세정보 조회 시 `(내비게이션을 위한)` 요청을 4번 보내며 지연이 생김
- 이를 해결하기 위해 옵션 추가